### PR TITLE
Add test.js to .npmignore

### DIFF
--- a/nodejs/.npmignore
+++ b/nodejs/.npmignore
@@ -1,1 +1,2 @@
 decrypt.js
+test.js


### PR DESCRIPTION
I think test.js doesn't need to be packaged.
