### PR TITLE
Change AES_GCM to aes-128-gcm

### DIFF
--- a/nodejs/ece.js
+++ b/nodejs/ece.js
@@ -5,7 +5,7 @@ var base64 = require('urlsafe-base64');
 
 var savedKeys = {};
 var keyLabels = {};
-var AES_GCM = 'id-aes128-GCM';
+var AES_GCM = 'aes-128-gcm';
 var PAD_SIZE = 2;
 var TAG_LENGTH = 16;
 var KEY_LENGTH = 16;


### PR DESCRIPTION
I am using an browserify version of node's crypto aes encryption, this is the only valid GCM cipher mode. For normal nodejs, it should be similar to id-aes128-GCM.
