### PR TITLE
Remove no longer needed intermediate standard

### DIFF
--- a/nodejs/ece.js
+++ b/nodejs/ece.js
@@ -142,13 +142,8 @@ function deriveKeyAndNonce(params, mode) {
   var keyInfo;
   var nonceInfo;
   if (padSize === 1) {
-    if (params.authSecret) {
-      keyInfo = info('aesgcm128', s.context);
-      nonceInfo = info('nonce', s.context);
-    } else {
-      keyInfo = 'Content-Encoding: aesgcm128';
-      nonceInfo = 'Content-Encoding: nonce';
-    }
+    keyInfo = 'Content-Encoding: aesgcm128';
+    nonceInfo = 'Content-Encoding: nonce';
   } else if (padSize === 2) {
     keyInfo = info('aesgcm', s.context);
     nonceInfo = info('nonce', s.context);

--- a/python/http_ece/__init__.py
+++ b/python/http_ece/__init__.py
@@ -67,12 +67,8 @@ def deriveKey(mode, salt, key=None, dh=None, keyid=None, authSecret=None, padSiz
         keyinfo = buildInfo(b"aesgcm", context)
         nonceinfo = buildInfo(b"nonce", context)
     elif padSize == 1:
-        if authSecret is not None:
-            keyinfo = buildInfo(b"aesgcm128", context)
-            nonceinfo = buildInfo(b"nonce", context)
-        else:
-            keyinfo = b"Content-Encoding: aesgcm128"
-            nonceinfo = b"Content-Encoding: nonce"
+        keyinfo = b"Content-Encoding: aesgcm128"
+        nonceinfo = b"Content-Encoding: nonce"
     else:
         raise Exception(u"unable to set context for padSize=" + str(padSize))
 


### PR DESCRIPTION
We can remove it, since https://bugzilla.mozilla.org/show_bug.cgi?id=1257821 has been uplifted to both Firefox 46 and Firefox 47.
