### PR TITLE
Add backwards compatibility with Node 0.10

### DIFF
--- a/nodejs/ece.js
+++ b/nodejs/ece.js
@@ -2,6 +2,7 @@
 
 var crypto = require('crypto');
 var base64 = require('urlsafe-base64');
+require('./shim');
 
 var savedKeys = {};
 var keyLabels = {};
@@ -55,7 +56,8 @@ function HKDF(salt, ikm, info, len) {
 
 function info(base, context) {
   var result = Buffer.concat([
-    new Buffer('Content-Encoding: ' + base + '\0', 'ascii'),
+    new Buffer('Content-Encoding: ' + base, 'ascii'),
+    new Buffer('\0'),
     context
   ]);
   keylog('info ' + base, result);
@@ -304,7 +306,8 @@ function encrypt(buffer, params) {
 function saveKey(id, key, dhLabel) {
   savedKeys[id] = key;
   if (dhLabel) {
-    keyLabels[id] = new Buffer(dhLabel + '\0', 'ascii');
+    keyLabels[id] = Buffer.concat([new Buffer(dhLabel, 'ascii'),
+                                   new Buffer('\0')]);
   }
 }
 

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -5,8 +5,8 @@
   "homepage": "https://github.com/martinthomson/encrypted-content-encoding",
   "bugs": "https://github.com/martinthomson/encrypted-content-encoding/issues",
   "author": {
-    "name" : "Martin Thomson",
-    "email" : "martin.thomson@gmail.com"
+    "name": "Martin Thomson",
+    "email": "martin.thomson@gmail.com"
   },
   "repository": {
     "type": "git",
@@ -14,9 +14,18 @@
   },
   "license": "MIT",
   "main": "./ece.js",
-  "scripts": { "test": "node ./test.js" },
-  "engines" : { "node" : ">=4.0.0" },
+  "scripts": {
+    "test": "node ./test.js"
+  },
+  "engines": {
+    "node": ">=0.10.0"
+  },
   "dependencies": {
+    "browserify-aes": "^1.0.6",
+    "buffer-compare-shim": "^1.0.0",
+    "buffer-io-shim": "^1.0.0",
+    "create-ecdh": "~4.0.0",
+    "semver": "~5.1.0",
     "urlsafe-base64": "~1.0.0"
   }
 }

--- a/nodejs/shim/index.js
+++ b/nodejs/shim/index.js
@@ -1,0 +1,11 @@
+var semver = require('semver');
+if (semver.satisfies(process.version, '>= 0.12.0')) {
+  return;
+}
+
+require('buffer-compare-shim');
+require('buffer-io-shim');
+var crypto = require('crypto');
+crypto.createECDH = require('create-ecdh');
+crypto.createCipheriv = require('browserify-aes/encrypter').createCipheriv;
+crypto.createDecipheriv = require('browserify-aes/decrypter').createDecipheriv;


### PR DESCRIPTION
This adds compatibility with Node 0.10 by shimming the missing parts.

Notes: 
- The weird concat with the null termination character (line 65 of ece.js) is on purpose: on node 0.10 it is considered as a space if the ascii encoding is specified.
