### PR TITLE
feat: Update to cryptography 1.9

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -27,7 +27,7 @@ setup(
     ],
     keywords='crypto http',
     install_requires=[
-        'cryptography~=1.8.1',
+        'cryptography~=1.9',
     ],
     tests_require=[
         'nose',


### PR DESCRIPTION
versions of cryptography < 1.9 have had several compilation errors.
We should switch to a more recent version to allow for packages to
update.

closes #38