### PR TITLE
Include tests and tox.ini in PyPI tarball

### DIFF
--- a/python/MANIFEST.in
+++ b/python/MANIFEST.in
@@ -1,1 +1,3 @@
 include README.rst
+include tox.ini
+recursive-include http_ece/tests *


### PR DESCRIPTION
In OpenBSD we use the regression tests in order to make sure that updates
work properly and that an update of a dependency doesn't break a package.
Having the regression tests in the PyPI tarball makes that much easier.