### PR TITLE
Tests don't actually use flake8 or mock

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -31,9 +31,7 @@ setup(
     ],
     tests_require=[
         'nose',
-        'mock',
         'coverage',
-        'flake8',
     ],
     test_suite="nose.collector",
     url='https://github.com/martinthomson/encrypted-content-encoding',


### PR DESCRIPTION
The tests don't actually use flake8 or mock so leave them off of the requirements for testing.