### PR TITLE
nodejs tweaks

### DIFF
--- a/nodejs/ece.js
+++ b/nodejs/ece.js
@@ -222,7 +222,7 @@ function deriveKeyAndNonce(header, mode, lookupKeyCallback) {
     nonceInfo = Buffer.from('Content-Encoding: nonce\0');
     secret = extractSecret(header, mode, lookupKeyCallback);
   } else {
-    throw new Error('Unable to set context for mode ' + params.version);
+    throw new Error('Unable to set context for mode ' + header.version);
   }
   var prk = HKDF_extract(header.salt, secret);
   var result = {

--- a/nodejs/test.js
+++ b/nodejs/test.js
@@ -8,7 +8,7 @@ var assert = require('assert');
 function usage() {
   console.log('Usage: node test.js [args]');
   console.log('  <version> - test only the specified version(s)');
-  console.log('    Supported: [aes128gcm,aesgcm,aesgcm128]');
+  console.log('    Supported: [aes128gcm,aesgcm]');
   console.log('  <test function> - test only the specified function(s)');
   console.log('  "verbose" enable logging for tests (export ECE_KEYLOG=1 for more)');
   console.log('  "text=..." sets the input string');
@@ -116,9 +116,6 @@ function generateInput(min) {
 }
 
 function rsoverhead(version) {
-  if (version === 'aesgcm128') {
-    return 1;
-  }
   if (version === 'aesgcm') {
     return 2;
   }
@@ -397,7 +394,7 @@ function useCustomCallback(version) {
 }
 
 validate();
-filterTests([ 'aesgcm128', 'aesgcm', 'aes128gcm' ])
+filterTests([ 'aesgcm', 'aes128gcm' ])
   .forEach(function(version) {
     filterTests([ useExplicitKey,
                   authenticationSecret,


### PR DESCRIPTION
The JS library `deriveKeyAndNonce ` doesn't support `aesgcm128` now so there's no point testing it.

By the way, your CircleCI isn't running now, perhaps it needs re-enabling? The last push to master actually showed the above error.
