### PR TITLE
Remove dependency urlsafe-base64

### DIFF
--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -8,11 +8,10 @@ content-encoding](https://tools.ietf.org/html/rfc8188)
 ```js
 var ece = require('http_ece');
 var crypto = require('crypto')
-var base64 = require('base64url');
 
 var parameters = {
-  key: base64.encode(crypto.randomBytes(16)),
-  salt: base64.encode(crypto.randomBytes(16))
+  key: crypto.randomBytes(16).toString('base64url'),
+  salt: crypto.randomBytes(16).toString('base64url')
 };
 var encrypted = ece.encrypt(data, parameters);
 

--- a/nodejs/decrypt-dh.js
+++ b/nodejs/decrypt-dh.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var base64 = require('urlsafe-base64');
 var crypto = require('crypto');
 var ece = require('./ece.js');
 
@@ -16,8 +15,8 @@ var receiver = crypto.createECDH('prime256v1');
 // 2. it barfs when you try to access the public key, even after you set it
 // This hack squelches the complaints at the cost of a few wasted cycles
 receiver.generateKeys();
-receiver.setPublicKey(base64.decode(process.argv[4]));
-receiver.setPrivateKey(base64.decode(process.argv[3]));
+receiver.setPublicKey(Buffer.from(process.argv[4], 'base64url'));
+receiver.setPrivateKey(Buffer.from(process.argv[3], 'base64url'));
 var keymap = {};
 
 var params = {
@@ -35,7 +34,7 @@ if (process.argv.length > 7) {
 keymap[params.keyid] = receiver;
 
 console.log("Params: " + JSON.stringify(params, null, 2));
-var result = ece.decrypt(base64.decode(process.argv[5]), params);
+var result = ece.decrypt(Buffer.from(process.argv[5], 'base64url'), params);
 
-console.log(base64.encode(result));
+console.log(result.toString('base64url'));
 console.log(result.toString('utf-8'));

--- a/nodejs/decrypt.js
+++ b/nodejs/decrypt.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var base64 = require('urlsafe-base64');
 var crypto = require('crypto');
 var ece = require('./ece.js');
 
@@ -23,7 +22,7 @@ if (process.argv.length > 4) {
 }
 
 console.log("Params: " + JSON.stringify(params, null, 2));
-var result = ece.decrypt(base64.decode(process.argv[3]), params);
+var result = ece.decrypt(Buffer.from(process.argv[3], 'base64url'), params);
 
-console.log(base64.encode(result));
+console.log(result.toString('base64url'));
 console.log(result.toString('utf-8'));

--- a/nodejs/ece.js
+++ b/nodejs/ece.js
@@ -15,7 +15,6 @@
  */
 
 var crypto = require('crypto');
-var base64 = require('urlsafe-base64');
 
 var AES_GCM = 'aes-128-gcm';
 var PAD_SIZE = { 'aes128gcm': 1, 'aesgcm': 2 };
@@ -29,7 +28,7 @@ var MODE_DECRYPT = 'decrypt';
 var keylog;
 if (process.env.ECE_KEYLOG === '1') {
   keylog = function(m, k) {
-    console.warn(m + ' [' + k.length + ']: ' + base64.encode(k));
+    console.warn(m + ' [' + k.length + ']: ' + k.toString('base64url'));
     return k;
   };
 } else {
@@ -39,7 +38,7 @@ if (process.env.ECE_KEYLOG === '1') {
 /* Optionally base64 decode something. */
 function decode(b) {
   if (typeof b === 'string') {
-    return base64.decode(b);
+    return Buffer.from(b, 'base64url');
   }
   return b;
 }

--- a/nodejs/encrypt-dh.js
+++ b/nodejs/encrypt-dh.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var base64 = require('urlsafe-base64');
 var crypto = require('crypto');
 var ece = require('./ece.js');
 
@@ -27,18 +26,18 @@ if (process.argv.length > 5) {
 var sender = crypto.createECDH('prime256v1');
 sender.generateKeys();
 if (params.senderPrivate) {
-  sender.setPrivateKey(base64.decode(params.senderPrivate));
+  sender.setPrivateKey(Buffer.from(params.senderPrivate, 'base64url'));
 } else {
-  params.senderPrivate = base64.encode(sender.getPrivateKey());
+  params.senderPrivate = sender.getPrivateKey().toString('base64url');
 }
 if (params.senderPublic) {
-  sender.setPublicKey(base64.decode(params.senderPublic));
+  sender.setPublicKey(Buffer.from(params.senderPublic, 'base64url'));
 } else {
-  params.senderPublic = base64.encode(sender.getPublicKey());
+  params.senderPublic = sender.getPublicKey().toString('base64url');
 }
 params.privateKey = sender;
 
 console.log("Params: " + JSON.stringify(params, null, 2));
-var result = ece.encrypt(base64.decode(process.argv[4]), params);
+var result = ece.encrypt(Buffer.from(process.argv[4], 'base64url'), params);
 
-console.log("Encrypted Message: " + base64.encode(result));
+console.log("Encrypted Message: " + result.toString('base64url'));

--- a/nodejs/encrypt.js
+++ b/nodejs/encrypt.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var base64 = require('urlsafe-base64');
 var crypto = require('crypto');
 var ece = require('./ece.js');
 
@@ -23,6 +22,6 @@ if (process.argv.length > 4) {
 }
 
 console.log("Params: " + JSON.stringify(params, null, 2));
-var result = ece.encrypt(base64.decode(process.argv[3]), params);
+var result = ece.encrypt(Buffer.from(process.argv[3], 'base64url'), params);
 
-console.log("Encrypted Message: " + base64.encode(result));
+console.log("Encrypted Message: " + result.toString('base64url'));

--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -1,0 +1,24 @@
+{
+  "name": "http_ece",
+  "version": "1.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "http_ece",
+      "version": "1.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "urlsafe-base64": "~1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/urlsafe-base64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/urlsafe-base64/-/urlsafe-base64-1.0.0.tgz",
+      "integrity": "sha512-RtuPeMy7c1UrHwproMZN9gN6kiZ0SvJwRaEzwZY0j9MypEkFqyBaKv176jvlPtg58Zh36bOkS0NFABXMHvvGCA=="
+    }
+  }
+}

--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -8,17 +8,9 @@
       "name": "http_ece",
       "version": "1.1.0",
       "license": "MIT",
-      "dependencies": {
-        "urlsafe-base64": "~1.0.0"
-      },
       "engines": {
         "node": ">=16"
       }
-    },
-    "node_modules/urlsafe-base64": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/urlsafe-base64/-/urlsafe-base64-1.0.0.tgz",
-      "integrity": "sha512-RtuPeMy7c1UrHwproMZN9gN6kiZ0SvJwRaEzwZY0j9MypEkFqyBaKv176jvlPtg58Zh36bOkS0NFABXMHvvGCA=="
     }
   }
 }

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -23,8 +23,5 @@
   },
   "engines": {
     "node": ">=16"
-  },
-  "dependencies": {
-    "urlsafe-base64": "~1.0.0"
   }
 }

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -22,7 +22,7 @@
     "test": "node ./test.js"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=16"
   },
   "dependencies": {
     "urlsafe-base64": "~1.0.0"

--- a/nodejs/test.js
+++ b/nodejs/test.js
@@ -2,7 +2,6 @@
 
 var crypto = require('crypto');
 var ece = require('./ece.js');
-var base64 = require('urlsafe-base64');
 var assert = require('assert');
 
 function usage() {
@@ -57,11 +56,11 @@ function filterTests(fullList) {
 
 function logbuf(msg, buf) {
   if (typeof buf === 'string') {
-    buf = base64.decode(buf);
+    buf = Buffer.from(buf, 'base64url');
   }
   log(msg + ': [' + buf.length + ']');
   for (var i = 0; i < buf.length; i += 48) {
-    log('    ' + base64.encode(buf.slice(i, i + 48)));
+    log('    ' + buf.slice(i, i + 48).toString('base64url'));
   }
 }
 
@@ -71,7 +70,7 @@ function reallySaveDump(data){
       var r = {};
       Object.keys(d).forEach(function(k) {
         if (Buffer.isBuffer(d[k])) {
-          r[k] = base64.encode(d[k]);
+          r[k] = d[k].toString('base64url');
         } else if (d[k] instanceof Object) {
           r[k] = dumpFix(d[k]);
         } else {
@@ -306,12 +305,12 @@ function useDH(version) {
   // keyData is used for cross library verification dumps
   var keyData = {
     sender: {
-      private: base64.encode(ephemeralKey.getPrivateKey()),
-      public: base64.encode(ephemeralKey.getPublicKey())
+      private: ephemeralKey.getPrivateKey().toString('base64url'),
+      public: ephemeralKey.getPublicKey().toString('base64url')
     },
     receiver: {
-      private: base64.encode(staticKey.getPrivateKey()),
-      public: base64.encode(staticKey.getPublicKey())
+      private: staticKey.getPrivateKey().toString('base64url'),
+      public: staticKey.getPublicKey().toString('base64url')
     }
   };
   encryptDecrypt(input, encryptParams, decryptParams, keyData);
@@ -323,30 +322,30 @@ function checkExamples(version) {
     {
       args: {
         version: 'aes128gcm',
-        key: base64.decode('yqdlZ-tYemfogSmv7Ws5PQ'),
+        key: Buffer.from('yqdlZ-tYemfogSmv7Ws5PQ', 'base64url'),
         keyid: '',
-        salt: base64.decode('I1BsxtFttlv3u_Oo94xnmw'),
+        salt: Buffer.from('I1BsxtFttlv3u_Oo94xnmw', 'base64url'),
         rs: 4096
       },
       plaintext: Buffer.from('I am the walrus'),
-      ciphertext: base64.decode('I1BsxtFttlv3u_Oo94xnmwAAEAAA-NAV' +
+      ciphertext: Buffer.from('I1BsxtFttlv3u_Oo94xnmwAAEAAA-NAV' +
                                 'ub2qFgBEuQKRapoZu-IxkIva3MEB1PD-' +
-                                'ly8Thjg'),
+                                'ly8Thjg', 'base64url'),
     },
     {
       args: {
         version: 'aes128gcm',
-        key: base64.decode('BO3ZVPxUlnLORbVGMpbT1Q'),
+        key: Buffer.from('BO3ZVPxUlnLORbVGMpbT1Q', 'base64url'),
         keyid: 'a1',
-        salt: base64.decode('uNCkWiNYzKTnBN9ji3-qWA'),
+        salt: Buffer.from('uNCkWiNYzKTnBN9ji3-qWA', 'base64url'),
         rs: 25,
         pad: 1
       },
       plaintext: Buffer.from('I am the walrus'),
-      ciphertext: base64.decode('uNCkWiNYzKTnBN9ji3-qWAAAABkCYTHO' +
+      ciphertext: Buffer.from('uNCkWiNYzKTnBN9ji3-qWAAAABkCYTHO' +
                                 'G8chz_gnvgOqdGYovxyjuqRyJFjEDyoF' +
                                 '1Fvkj6hQPdPHI51OEUKEpgz3SsLWIqS_' +
-                                'uA')
+                                'uA', 'base64url')
     }
   ].filter(function(v) {
     return v.args.version === version;


### PR DESCRIPTION
Fixes: #68 

Bump up the Node version to use minimum 16. This will allow use of Buffer API with built-in support for base-64, removing dependency over urlsafe-base64.