### PR TITLE
Nodev18 issue : Fix unknown URL base encoding error (base64url to base64)

### DIFF
--- a/nodejs/ece.js
+++ b/nodejs/ece.js
@@ -38,7 +38,7 @@ if (process.env.ECE_KEYLOG === '1') {
 /* Optionally base64 decode something. */
 function decode(b) {
   if (typeof b === 'string') {
-    return Buffer.from(b, 'base64url');
+    return Buffer.from(b, 'base64');
   }
   return b;
 }


### PR DESCRIPTION
This PR addresses the below issue :

TypeError [ERR_UNKNOWN_ENCODING]: Unknown encoding: base64url

in Node v18, following error comes , so to fix this we need to change from base64url to base64


